### PR TITLE
feat: fetch and display incidents from API

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     environment:
       - ELASTICSEARCH_URL=http://elasticsearch:9200
       - ELASTICSEARCH_INDEX=incidents
+      - GTFS_FEED_PATH=  
     depends_on:
       elasticsearch:
         condition: service_healthy
@@ -27,16 +28,6 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-
-  kibana:
-    image: docker.elastic.co/kibana/kibana:8.12.1
-    environment:
-      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
-    ports:
-      - "5601:5601"
-    depends_on:
-      elasticsearch:
-        condition: service_healthy
 
 volumes:
   esdata:


### PR DESCRIPTION
- Remove Kibana from docker-compose.
- Add GTFS_FEED_PATH environment variable to the api service.
- Implement API calls in `IncidentService` to fetch all and latest incidents.
- Replace mocked incident data in `IncidentsScreen` with data fetched from the REST API.
- Add loading and error states to the UI.
- Add a mapper to convert API incident items to UI models.